### PR TITLE
Renamed var 'sysdig_node_analyzer_api_endpoint'

### DIFF
--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -27,7 +27,7 @@ variableGroups:
     - sysdig_access_key
     - sysdig_settings_collector
     - sysdig_settings_collector_port
-    - sysdig_node_analyzer_api_endpoint
+    - sysdig_secure_api_endpoint
 
   - title: "Sysdig <> Snyk Integration"
     variables:
@@ -124,9 +124,9 @@ variables:
     title: "Sysdig Agent Collector Port"
     required: true
 
-  sysdig_node_analyzer_api_endpoint:
+  sysdig_secure_api_endpoint:
     type: string
-    title: "Sysdig Node Analyzer API endpoint"
+    title: "Sysdig Secure Endpoint for node analyzer"
     required: true
 
   sysdig_snyk_integration:

--- a/terraform/sysdig-agent.tf
+++ b/terraform/sysdig-agent.tf
@@ -40,7 +40,7 @@ resource "helm_release" "sysdig_agent" {
   }
   set {
     name  = "nodeAnalyzer.apiEndpoint"
-    value = var.sysdig_node_analyzer_api_endpoint
+    value = var.sysdig_secure_api_endpoint
   }
   set {
     name  = "ebpf.enabled"

--- a/terraform/sysdig-variables.tf
+++ b/terraform/sysdig-variables.tf
@@ -17,7 +17,7 @@ variable "sysdig_settings_collector_port" {
   description = "Sysdig Agent Collector Port"
 }
 
-variable "sysdig_node_analyzer_api_endpoint" {
+variable "sysdig_secure_api_endpoint" {
   default     = ""
   description = "Sysdig secure API endpoint, without protocol (i.e. secure.sysdig.com)"
 }


### PR DESCRIPTION
Renamed var 'sysdig_node_analyzer_api_endpoint' to 'sysdig_secure_api_endpoint' to match the endpoints documentation